### PR TITLE
added test that runs the example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,11 @@ jobs:
       - name: install package
         run: |
           pip install --upgrade pip
-          pip install .
+          pip install .[test]
           python -c "import NeSST"
+
+      - name: run examples
+        run: |
+          cd example
+          jupyter nbconvert --to python 'NeSST Guide.ipynb'
+          ipython 'NeSST Guide.py'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - master
   pull_request:
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,12 @@ jobs:
       - name: install package
         run: |
           pip install --upgrade pip
-          pip install .[test]
+          pip install .
           python -c "import NeSST"
+
+      - name: install package with testing dependencies
+        run: |
+          pip install .[test]
 
       - name: run examples
         run: |

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,5 +18,10 @@ install_requires =
     numpy
     scipy
 
+[options.extras_require]
+test =
+    pytest
+    jupyter
+
 [options.package_data]
 * = data/*.dat, data/*.txt

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ install_requires =
 test =
     pytest
     jupyter
+    matplotlib
 
 [options.package_data]
 * = data/*.dat, data/*.txt


### PR DESCRIPTION
extending the minimal CI so that it runs the example notebook. First it converts the note book to a py script and then it runs the py file with ipython. Ipython is needed instead of python as the notebook contains some python magic commands. As the filename has a space in it then quotes are needed in the terminal commands but I wanted to avoid a large diff so left the filename as it is